### PR TITLE
dependencies: add lineageos

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -4,5 +4,11 @@
 		"repository":"TeamWin/android_kernel_samsung_universal9810",
 		"target_path":"kernel/samsung/universal9810",
 		"revision":"android-8.1"
+	},
+	{
+		"remote":"github",
+		"repository":"LineageOS/android_hardware_samsung",
+		"target_path":"hardware/samsung",
+		"revision":"cm-14.1"
 	}
 ]


### PR DESCRIPTION
Many people are building with the omni tree, hence they require the lineageos samsung repo